### PR TITLE
Made it possibly to specify where in the markdown file the summary is placed.

### DIFF
--- a/summarizeMD
+++ b/summarizeMD
@@ -7,7 +7,7 @@ require 'optparse/time'
 require 'ostruct'
 require 'yaml'
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 
 class MDUtils
 

--- a/summarizeMD
+++ b/summarizeMD
@@ -24,9 +24,7 @@ class MDUtils
 		puts "Generating summary for file " + filename
 
 		# In order to be sure to not write on existing file
-		timeNow = Time.now.to_f
-		tmpfilename = "tmp_00_" + timeNow.inspect + ".md"
-		temp_file = File.new(tmpfilename, "w")
+		temp_file = Tempfile.new("summarizeMd")
 
 		summary = "\#Summary \n\n"
 		forbidden_words = ['Table of contents', 'define', 'pragma']
@@ -49,27 +47,52 @@ class MDUtils
 			 		temp_file.puts line
 			 	end   
 		   	end
-
-			temp_file.close
-			summary += "  \n\n"
-			outputFilename = "summarized_" + filename
-			if !options.output.empty? 
-				outputFilename = options.output
-				outputComponents = outputFilename.split(".")
-
-				if outputComponents.last.downcase != "md" 
-					outputFilename += ".md"
-					if options.verbose 
-				    	puts "Forcing adding extension."
-				    end
-				end
-				
-			end
-			system("echo \"#{summary}\" | cat - #{tmpfilename} > #{outputFilename}")
-		    system("rm #{tmpfilename}")
-		    puts "Done.\n"
+                        temp_file.close
 		end
-	end #(end summarize)	
+                summary += "  \n\n"
+        
+                with_output_file(options, filename) do |output_file|
+                   prepend_to_file(summary, temp_file, output_file) 
+                end
+                
+                temp_file.unlink
+                puts "Done.\n"
+	end #(end summarize)
+        
+        def self.prepend_to_file(toPrepend, source_file, target_file)
+            File.open(target_file, 'w') do |fo|
+                fo.puts(toPrepend)
+                File.foreach(source_file) do |li|
+                    fo.puts li
+                end
+            end
+        end
+        
+        def self.with_output_file(options, filename)
+            outputFilename = "summarized_" + filename
+            if !options.output.empty? 
+                outputFilename = options.output
+                outputComponents = outputFilename.split(".")
+                if outputComponents.last.downcase != "md" 
+                    outputFilename += ".md"
+                    if options.verbose 
+                        puts "Forcing adding extension."
+                    end
+                end
+            end
+            
+            if File.file?(outputFilename) && !options.force
+                puts "output file exists. Use --force or -f to overwrite it."
+                exit 1
+            elsif File.directory?(outputFilename)
+                puts "output file cannot be a directory"
+                exit 2
+            else
+               File.open(outputFilename, "w") do |output_file|
+                  yield output_file 
+               end
+            end
+        end
 
 end
 
@@ -87,6 +110,7 @@ class OptparseSummarize
     options = OpenStruct.new
     options.encoding = "utf8"
     options.verbose = false
+    options.force = false
     options.output = String.new
 
     opt_parser = OptionParser.new do |opts|
@@ -104,6 +128,11 @@ class OptparseSummarize
       # Boolean switch.
       opts.on("-v", "--[no-]verbose", "Run verbosely") do |v|
         options.verbose = v
+      end
+      
+      # Boolean switch.
+      opts.on("-f", "--force", "force writing the output file, even if its overwrite an existing file") do |f|
+        options.force = f
       end
 
       opts.separator ""

--- a/summarizeMD
+++ b/summarizeMD
@@ -52,7 +52,11 @@ class MDUtils
                 summary += "  \n\n"
         
                 with_output_file(options, filename) do |output_file|
-                   prepend_to_file(summary, temp_file, output_file) 
+                    if (options.replace_summary_token.empty?)
+                        prepend_to_file(summary, temp_file, output_file) 
+                    else
+                        replace_token_with(options.replace_summary_token, summary, temp_file, output_file)
+                    end
                 end
                 
                 temp_file.unlink
@@ -64,6 +68,18 @@ class MDUtils
                 fo.puts(toPrepend)
                 File.foreach(source_file) do |li|
                     fo.puts li
+                end
+            end
+        end
+        
+        def self.replace_token_with(token, toPrepend, source_file, target_file)
+            File.open(target_file, 'w') do |fo|
+                File.foreach(source_file) do |li|
+                    if li.include?(token)
+                        fo.puts toPrepend
+                    else
+                        fo.puts li
+                    end
                 end
             end
         end
@@ -112,6 +128,7 @@ class OptparseSummarize
     options.verbose = false
     options.force = false
     options.output = String.new
+    options.replace_summary_token = String.new
 
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: summarizeMD <filename> [options]"
@@ -123,6 +140,11 @@ class OptparseSummarize
       opts.on("-o", "--output [filename]",
               "Specify output filename") do |out|
         options.output << out
+      end
+      
+      opts.on("-t", "--replace_summary_token [summary_token]",
+              "Replace the line containing the supplied token, with the sumrmary, instead of putting the summary in the top of the file.") do |out|
+        options.replace_summary_token << out
       end
 
       # Boolean switch.

--- a/summarizeMD
+++ b/summarizeMD
@@ -26,7 +26,7 @@ class MDUtils
 		# In order to be sure to not write on existing file
 		temp_file = Tempfile.new("summarizeMd")
 
-		summary = "\#Summary \n\n"
+		summary = generate_sumary_heading(options)
 		forbidden_words = ['Table of contents', 'define', 'pragma']
 
 		File.open(filename, 'r') do |f|
@@ -109,6 +109,17 @@ class MDUtils
                end
             end
         end
+        
+        def self.generate_sumary_heading(options)
+            if options.heading_level == 0
+                return String.new
+            else
+                heading = String.new
+                options.heading_level.times { heading << "\#" }
+                heading << " Summary \n\n"
+                return heading
+            end
+        end
 
 end
 
@@ -129,6 +140,7 @@ class OptparseSummarize
     options.force = false
     options.output = String.new
     options.replace_summary_token = String.new
+    options.heading_level = 1
 
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: summarizeMD <filename> [options]"
@@ -143,8 +155,13 @@ class OptparseSummarize
       end
       
       opts.on("-t", "--replace_summary_token [summary_token]",
-              "Replace the line containing the supplied token, with the sumrmary, instead of putting the summary in the top of the file.") do |out|
+              "Replace the line containing the supplied token, with the sumrmary, instead of putting the summary in the top of the file. If the token is not found, then no summary is inserted.") do |out|
         options.replace_summary_token << out
+      end
+      
+      opts.on("-l", "--heading_level [heading level]", Integer,
+              "Specify the heading level, eg. The number of ## to insert before the Sumary heading. Set this to 0 to not add a heading to the summary.") do |l|
+        options.heading_level = l
       end
 
       # Boolean switch.
@@ -153,7 +170,7 @@ class OptparseSummarize
       end
       
       # Boolean switch.
-      opts.on("-f", "--force", "force writing the output file, even if its overwrite an existing file") do |f|
+      opts.on("-f", "--[no-]force", "force writing the output file, even if its overwrite an existing file") do |f|
         options.force = f
       end
 
@@ -162,16 +179,22 @@ class OptparseSummarize
 
       # No argument, shows at tail.  This will print an options summary.
       # Try it and see!
-      opts.on_tail("-h", "--help", "Show this message") do
+      opts.on("-h", "--help", "Show this message") do
         puts opts
         exit
       end
 
       # Another typical switch to print the version.
-      opts.on_tail("--version", "Show version") do
+      opts.on("--version", "Show version") do
         puts "#{VERSION}"
         exit
       end
+      
+      opts.separator ""
+      opts.separator "Exit codes:"
+      opts.separator "    1 = output file exists, and called without --force (-f)"
+      opts.separator "    2 = output file cannot be a directory"
+      opts.separator "    3 = --heading_level (-l) must be a positive integer or zero"
     end
 
     opt_parser.parse!(args) 
@@ -185,6 +208,10 @@ end  # class OptparseExample
 
 
 options = OptparseSummarize.parse(ARGV)
+if options.heading_level < 0
+    puts "--heading_level (-l) must be a positive integer or zero"
+    exit 3
+end
 
 mdUtils = MDUtils.summarize([ARGV[0], options]);
 


### PR DESCRIPTION
This fixes #5 

This is done by adding the options --replace_summary_token [summary_token]. When called with this option, the script replaced the line containing [summary_token] with the summary, instaed of placing it in the top.

Also made some other improvements on the way:

* No shell commands, everything is now done in plain ruby.
* It now only overwrites output files if called with --force or -f
* Its now possibly to specify what heading level the heading of the summary should have with --heading_level [integer], or to disable the summary header by specifying 0.
* It now creates tempfiles in the operating system temp directory, instead of the current dir.