### PR TITLE
fix(summarizeMD): Fix title in italic

### DIFF
--- a/summarizeMD
+++ b/summarizeMD
@@ -65,9 +65,12 @@ class MDUtils
 				end
 				
 			end
-			system("echo \"#{summary}\" | cat - #{tmpfilename} > #{outputFilename}")
-		    system("rm #{tmpfilename}")
-		    puts "Done.\n"
+      File.open(outputFilename, 'w') { |f| f.write summary}
+      f = File.open(tmpfilename, 'r')
+      File.write(outputFilename, f.read(), mode: 'a')
+      f.close
+      system("rm #{tmpfilename}")
+      puts "Done.\n"
 		end
 	end #(end summarize)	
 


### PR DESCRIPTION
This PR is related to https://github.com/velthune/summarizeMD/issues/9


STATE:
When a title is in italic form the script fails.

SOLUTION:
Change the way the output file is generated.

JIRA: master

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>
